### PR TITLE
临时修复 Informer 连不上后端api的时候不断watch的问题

### DIFF
--- a/pkg/client/cache.go
+++ b/pkg/client/cache.go
@@ -97,14 +97,14 @@ func (cs *ClusterSet) Complete(cfg []byte) error {
 		return err
 	}
 
-	sharedInformer, cancel, err := NewSharedInformers(cs.Config)
-	if err != nil {
-		return err
-	}
-	cs.Informer = &PixiuInformer{
-		Shared: sharedInformer,
-		Cancel: cancel,
-	}
+	//sharedInformer, cancel, err := NewSharedInformers(cs.Config)
+	//if err != nil {
+	//	return err
+	//}
+	//cs.Informer = &PixiuInformer{
+	//	Shared: sharedInformer,
+	//	Cancel: cancel,
+	//}
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
