### PR TITLE
feat: add AI provider and account management

### DIFF
--- a/api/server/router/assistant/account_routes.go
+++ b/api/server/router/assistant/account_routes.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/caoyingjunz/pixiu/api/server/httputils"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+type accountMeta struct {
+	AccountId int64 `uri:"accountId" binding:"required"`
+}
+
+func (r *router) createAccount(c *gin.Context) {
+	resp := httputils.NewResponse()
+	var req types.CreateAIAccountRequest
+	if err := httputils.ShouldBindAny(c, &req, nil, nil); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	if err := r.c.Assistant().Account().Create(c, &req); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	httputils.SetSuccess(c, resp)
+}
+
+func (r *router) updateAccount(c *gin.Context) {
+	resp := httputils.NewResponse()
+	var meta accountMeta
+	var req types.UpdateAIAccountRequest
+	if err := httputils.ShouldBindAny(c, &req, &meta, nil); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	req.Id = meta.AccountId
+	if err := r.c.Assistant().Account().Update(c, &req); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	httputils.SetSuccess(c, resp)
+}
+
+func (r *router) deleteAccount(c *gin.Context) {
+	resp := httputils.NewResponse()
+	var meta accountMeta
+	if err := httputils.ShouldBindAny(c, nil, &meta, nil); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	if err := r.c.Assistant().Account().Delete(c, meta.AccountId); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	httputils.SetSuccess(c, resp)
+}
+
+func (r *router) getAccount(c *gin.Context) {
+	resp := httputils.NewResponse()
+	var meta accountMeta
+	var err error
+	if err = httputils.ShouldBindAny(c, nil, &meta, nil); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	if resp.Result, err = r.c.Assistant().Account().Get(c, meta.AccountId); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	httputils.SetSuccess(c, resp)
+}
+
+func (r *router) listAccounts(c *gin.Context) {
+	resp := httputils.NewResponse()
+	var opts types.ListOptions
+	var err error
+	if err = httputils.ShouldBindAny(c, nil, nil, &opts); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	if resp.Result, err = r.c.Assistant().Account().List(c, opts); err != nil {
+		httputils.SetFailed(c, resp, err)
+		return
+	}
+	httputils.SetSuccess(c, resp)
+}

--- a/api/server/router/assistant/assistant.go
+++ b/api/server/router/assistant/assistant.go
@@ -27,6 +27,7 @@ import (
 const (
 	assistantBaseURL    = "/pixiu/assistant"
 	providerBaseURL     = assistantBaseURL + "/providers"
+	accountBaseURL      = assistantBaseURL + "/accounts"
 	conversationBaseURL = assistantBaseURL + "/conversations"
 	messageBaseURL      = assistantBaseURL + "/messages"
 )
@@ -55,6 +56,19 @@ func (r *router) initRoutes(ginEngine *gin.Engine) {
 		},
 	}
 	providerGroup.Register(ginEngine.Group(providerBaseURL), r.c.APIResource())
+
+	accountGroup := &apiregistry.Group{
+		Name:    "智能助手",
+		BaseURL: accountBaseURL,
+		Entries: []apiregistry.RouteEntry{
+			{Method: "POST", RelativePath: "", Handler: r.createAccount, Description: "Create assistant account"},
+			{Method: "PUT", RelativePath: "/:accountId", Handler: r.updateAccount, Description: "Update assistant account"},
+			{Method: "DELETE", RelativePath: "/:accountId", Handler: r.deleteAccount, Description: "Delete assistant account"},
+			{Method: "GET", RelativePath: "", Handler: r.listAccounts, Description: "List assistant accounts"},
+			{Method: "GET", RelativePath: "/:accountId", Handler: r.getAccount, Description: "Get assistant account"},
+		},
+	}
+	accountGroup.Register(ginEngine.Group(accountBaseURL), r.c.APIResource())
 
 	conversationGroup := &apiregistry.Group{
 		Name:    "智能助手",

--- a/cmd/app/options/bootstrap.go
+++ b/cmd/app/options/bootstrap.go
@@ -91,6 +91,41 @@ var defaultDistributionCatalog = []struct {
 	},
 }
 
+var defaultAIProviderCatalog = []pixiuModel.AIProvider{
+	{
+		Name:        "openai",
+		BaseURL:     "https://api.openai.com",
+		Protocol:    "openai_responses",
+		Description: "OpenAI official API",
+		MaxTokens:   4096,
+		Builtin:     true,
+	},
+	{
+		Name:        "deepseek",
+		BaseURL:     "https://api.deepseek.com",
+		Protocol:    "openai_chat",
+		Description: "DeepSeek official API",
+		MaxTokens:   4096,
+		Builtin:     true,
+	},
+	{
+		Name:        "siliconflow",
+		BaseURL:     "https://api.siliconflow.cn/v1",
+		Protocol:    "openai_chat",
+		Description: "SiliconFlow official API",
+		MaxTokens:   4096,
+		Builtin:     true,
+	},
+	{
+		Name:        "zhipu",
+		BaseURL:     "https://open.bigmodel.cn/api/paas/v4",
+		Protocol:    "openai_chat",
+		Description: "Zhipu GLM official API",
+		MaxTokens:   4096,
+		Builtin:     true,
+	},
+}
+
 var defaultRunners = []struct {
 	name        string
 	engineImage string
@@ -116,6 +151,9 @@ func (o *Options) bootstrapDatabase() error {
 	if err := o.bootstrapRootUser(ctx); err != nil {
 		return err
 	}
+	if err := o.bootstrapAIProviders(ctx); err != nil {
+		return err
+	}
 	// 初始化操作系统
 	if err := o.bootstrapDistributions(ctx); err != nil {
 		return err
@@ -123,6 +161,16 @@ func (o *Options) bootstrapDatabase() error {
 	// 初始化 Runner
 	if err := o.bootstrapRunners(ctx); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (o *Options) bootstrapAIProviders(ctx context.Context) error {
+	for i := range defaultAIProviderCatalog {
+		provider := defaultAIProviderCatalog[i]
+		if err := o.Factory.Assistant().Provider().EnsureBuiltin(ctx, &provider); err != nil {
+			return fmt.Errorf("failed to initialize ai provider %s: %v", provider.Name, err)
+		}
 	}
 	return nil
 }

--- a/pkg/controller/account/account.go
+++ b/pkg/controller/account/account.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package account
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	apierrors "github.com/caoyingjunz/pixiu/api/server/errors"
+	"github.com/caoyingjunz/pixiu/api/server/httputils"
+	"github.com/caoyingjunz/pixiu/cmd/app/config"
+	"github.com/caoyingjunz/pixiu/pkg/db"
+	"github.com/caoyingjunz/pixiu/pkg/db/model"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+	utilerrors "github.com/caoyingjunz/pixiu/pkg/util/errors"
+)
+
+type Interface interface {
+	Create(ctx context.Context, req *types.CreateAIAccountRequest) error
+	Update(ctx context.Context, req *types.UpdateAIAccountRequest) error
+	Delete(ctx context.Context, id int64) error
+	Get(ctx context.Context, id int64) (*types.AIAccount, error)
+	List(ctx context.Context, listOption types.ListOptions) (interface{}, error)
+}
+
+type controller struct {
+	cc      config.Config
+	factory db.ShareDaoFactory
+}
+
+func New(cfg config.Config, f db.ShareDaoFactory) Interface {
+	return &controller{cc: cfg, factory: f}
+}
+
+func (c *controller) Create(ctx context.Context, req *types.CreateAIAccountRequest) error {
+	if err := validateAccountFields(req.Name, req.APIKey, req.Model, req.ProviderId, true); err != nil {
+		return err
+	}
+	if err := c.ensureProvider(ctx, req.ProviderId); err != nil {
+		return err
+	}
+	userId, err := httputils.GetUserIdFromContext(ctx)
+	if err != nil {
+		return apierrors.NewError(fmt.Errorf("failed to get current user"), http.StatusUnauthorized)
+	}
+
+	_, err = c.factory.Assistant().Account().Create(ctx, &model.AIAccount{
+		UserId:     userId,
+		Name:       strings.TrimSpace(req.Name),
+		APIKey:     strings.TrimSpace(req.APIKey),
+		ModelName:  strings.TrimSpace(req.Model),
+		ProviderId: req.ProviderId,
+	})
+	if err != nil {
+		klog.Errorf("failed to create ai account: %v", err)
+		return apierrors.ErrServerInternal
+	}
+	return nil
+}
+
+func (c *controller) Update(ctx context.Context, req *types.UpdateAIAccountRequest) error {
+	if err := validateAccountFields(req.Name, req.APIKey, req.Model, req.ProviderId, false); err != nil {
+		return err
+	}
+	if err := c.ensureProvider(ctx, req.ProviderId); err != nil {
+		return err
+	}
+
+	old, err := c.factory.Assistant().Account().Get(ctx, req.Id)
+	if err != nil {
+		klog.Errorf("failed to get ai account(%d): %v", req.Id, err)
+		return apierrors.ErrServerInternal
+	}
+	if old == nil {
+		return apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
+	}
+	if err = ensureAccountOwner(ctx, old); err != nil {
+		return err
+	}
+
+	updates := map[string]interface{}{
+		"name":        strings.TrimSpace(req.Name),
+		"model":       strings.TrimSpace(req.Model),
+		"provider_id": req.ProviderId,
+	}
+	if strings.TrimSpace(req.APIKey) != "" {
+		updates["api_key"] = strings.TrimSpace(req.APIKey)
+	}
+	if err = c.factory.Assistant().Account().Update(ctx, req.Id, req.ResourceVersion, updates); err != nil {
+		if utilerrors.IsRecordNotFound(err) {
+			return apierrors.NewError(fmt.Errorf("ai account not found or resource version conflict"), http.StatusConflict)
+		}
+		klog.Errorf("failed to update ai account(%d): %v", req.Id, err)
+		return apierrors.ErrServerInternal
+	}
+	return nil
+}
+
+func (c *controller) Delete(ctx context.Context, id int64) error {
+	object, err := c.factory.Assistant().Account().Get(ctx, id)
+	if err != nil {
+		klog.Errorf("failed to get ai account(%d): %v", id, err)
+		return apierrors.ErrServerInternal
+	}
+	if object == nil {
+		return apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
+	}
+	if err = ensureAccountOwner(ctx, object); err != nil {
+		return err
+	}
+	if err := c.factory.Assistant().Account().Delete(ctx, id); err != nil {
+		if utilerrors.IsRecordNotFound(err) {
+			return apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
+		}
+		klog.Errorf("failed to delete ai account(%d): %v", id, err)
+		return apierrors.ErrServerInternal
+	}
+	return nil
+}
+
+func (c *controller) Get(ctx context.Context, id int64) (*types.AIAccount, error) {
+	object, err := c.factory.Assistant().Account().Get(ctx, id)
+	if err != nil {
+		klog.Errorf("failed to get ai account(%d): %v", id, err)
+		return nil, apierrors.ErrServerInternal
+	}
+	if object == nil {
+		return nil, apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
+	}
+	if err = ensureAccountOwner(ctx, object); err != nil {
+		return nil, err
+	}
+	return modelToType(object), nil
+}
+
+func (c *controller) List(ctx context.Context, listOption types.ListOptions) (interface{}, error) {
+	listOption.SetDefaultPageOption()
+	userId, err := httputils.GetUserIdFromContext(ctx)
+	if err != nil {
+		return nil, apierrors.NewError(fmt.Errorf("failed to get current user"), http.StatusUnauthorized)
+	}
+	opts := []db.Options{
+		db.WithUser(userId),
+		db.WithAIProviderId(listOption.ProviderId),
+		db.WithNameLike(listOption.NameSelector),
+	}
+
+	total, err := c.factory.Assistant().Account().Count(ctx, opts...)
+	if err != nil {
+		klog.Errorf("failed to count ai accounts: %v", err)
+		return nil, apierrors.ErrServerInternal
+	}
+	offset := (listOption.Page - 1) * listOption.Limit
+	opts = append(opts, db.WithModifyOrderByDesc(), db.WithOffset(offset), db.WithLimit(listOption.Limit))
+	objects, err := c.factory.Assistant().Account().List(ctx, opts...)
+	if err != nil {
+		klog.Errorf("failed to list ai accounts: %v", err)
+		return nil, apierrors.ErrServerInternal
+	}
+
+	items := make([]types.AIAccount, 0, len(objects))
+	for i := range objects {
+		items = append(items, *modelToType(&objects[i]))
+	}
+	return types.PageResult{
+		PageRequest: types.PageRequest{Page: listOption.Page, Limit: listOption.Limit},
+		Total:       total,
+		Items:       items,
+	}, nil
+}
+
+func (c *controller) ensureProvider(ctx context.Context, providerId int64) error {
+	provider, err := c.factory.Assistant().Provider().Get(ctx, providerId)
+	if err != nil {
+		klog.Errorf("failed to get ai provider(%d): %v", providerId, err)
+		return apierrors.ErrServerInternal
+	}
+	if provider == nil {
+		return apierrors.NewError(fmt.Errorf("ai provider not found"), http.StatusBadRequest)
+	}
+	return nil
+}
+
+func modelToType(object *model.AIAccount) *types.AIAccount {
+	result := &types.AIAccount{
+		PixiuMeta:  types.PixiuMeta{Id: object.Id, ResourceVersion: object.ResourceVersion},
+		TimeMeta:   types.TimeMeta{GmtCreate: object.GmtCreate, GmtModified: object.GmtModified},
+		Name:       object.Name,
+		APIKey:     maskAPIKey(object.APIKey),
+		Model:      object.ModelName,
+		ProviderId: object.ProviderId,
+		UserId:     object.UserId,
+	}
+	if object.Provider != nil {
+		result.Provider = &types.AIProvider{
+			PixiuMeta:   types.PixiuMeta{Id: object.Provider.Id, ResourceVersion: object.Provider.ResourceVersion},
+			TimeMeta:    types.TimeMeta{GmtCreate: object.Provider.GmtCreate, GmtModified: object.Provider.GmtModified},
+			Name:        object.Provider.Name,
+			BaseURL:     object.Provider.BaseURL,
+			Protocol:    string(object.Provider.Protocol),
+			Description: object.Provider.Description,
+			MaxTokens:   object.Provider.MaxTokens,
+		}
+	}
+	return result
+}
+
+func ensureAccountOwner(ctx context.Context, object *model.AIAccount) error {
+	userId, err := httputils.GetUserIdFromContext(ctx)
+	if err != nil {
+		return apierrors.NewError(fmt.Errorf("failed to get current user"), http.StatusUnauthorized)
+	}
+	if object == nil || object.UserId != userId {
+		return apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
+	}
+	return nil
+}
+
+func maskAPIKey(apiKey string) string {
+	apiKey = strings.TrimSpace(apiKey)
+	if len(apiKey) <= 8 {
+		return "********"
+	}
+	return apiKey[:4] + "****" + apiKey[len(apiKey)-4:]
+}
+
+func validateAccountFields(name, apiKey, model string, providerId int64, requireAPIKey bool) error {
+	if strings.TrimSpace(name) == "" {
+		return apierrors.NewError(fmt.Errorf("name is required"), http.StatusBadRequest)
+	}
+	if requireAPIKey && strings.TrimSpace(apiKey) == "" {
+		return apierrors.NewError(fmt.Errorf("api_key is required"), http.StatusBadRequest)
+	}
+	if strings.TrimSpace(model) == "" {
+		return apierrors.NewError(fmt.Errorf("model is required"), http.StatusBadRequest)
+	}
+	if providerId <= 0 {
+		return apierrors.NewError(fmt.Errorf("provider_id is required"), http.StatusBadRequest)
+	}
+	return nil
+}

--- a/pkg/controller/assistant/assistant.go
+++ b/pkg/controller/assistant/assistant.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/caoyingjunz/pixiu/cmd/app/config"
+	"github.com/caoyingjunz/pixiu/pkg/controller/account"
 	"github.com/caoyingjunz/pixiu/pkg/controller/conversation"
 	"github.com/caoyingjunz/pixiu/pkg/controller/message"
 	"github.com/caoyingjunz/pixiu/pkg/controller/provider"
@@ -37,6 +38,7 @@ type Interface interface {
 	Stream(ctx context.Context, req *types.AIRespondRequest, emit func(*types.AIStreamEvent) error) (*types.AIRespondResponse, error)
 
 	Provider() provider.Interface
+	Account() account.Interface
 	Conversation() conversation.Interface
 	Message() message.Interface
 }
@@ -46,6 +48,7 @@ type controller struct {
 	factory      db.ShareDaoFactory
 	client       *http.Client
 	provider     provider.Interface
+	account      account.Interface
 	conversation conversation.Interface
 	message      message.Interface
 }
@@ -56,6 +59,7 @@ func New(cfg config.Config, f db.ShareDaoFactory) Interface {
 		factory:      f,
 		client:       &http.Client{Timeout: 60 * time.Second},
 		provider:     provider.New(cfg, f),
+		account:      account.New(cfg, f),
 		conversation: conversation.New(cfg, f),
 		message:      message.New(cfg, f),
 	}
@@ -63,6 +67,10 @@ func New(cfg config.Config, f db.ShareDaoFactory) Interface {
 
 func (c *controller) Provider() provider.Interface {
 	return c.provider
+}
+
+func (c *controller) Account() account.Interface {
+	return c.account
 }
 
 func (c *controller) Conversation() conversation.Interface {

--- a/pkg/controller/assistant/openai_chat.go
+++ b/pkg/controller/assistant/openai_chat.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	apierrors "github.com/caoyingjunz/pixiu/api/server/errors"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+type chatStreamResult struct {
+	Raw              map[string]interface{}
+	Text             string
+	ResponseId       string
+	ToolCalls        []responseToolCall
+	AssistantMessage map[string]interface{}
+}
+
+type chatToolCallAccumulator struct {
+	Index     int
+	Id        string
+	Name      string
+	Arguments strings.Builder
+}
+
+func (c *controller) runChatCompletionsLoopStream(
+	ctx context.Context,
+	endpoint, apiKey, modelName string,
+	maxTokens int,
+	inputItems []map[string]interface{},
+	emit func(*types.AIStreamEvent) error,
+) (map[string]interface{}, string, string, error) {
+	messages := responseInputToChatMessages(inputItems)
+	messages = append([]map[string]interface{}{{"role": "system", "content": c.defaultAIInstructions()}}, messages...)
+	tools := toChatCompletionsTools(c.buildTools())
+
+	for i := 0; i < 8; i++ {
+		_ = emit(&types.AIStreamEvent{Type: "status", Stage: "model", Message: "AI is generating a response", Model: modelName})
+		result, err := c.callChatCompletionsStream(ctx, endpoint, apiKey, modelName, maxTokens, messages, tools, emit)
+		if err != nil {
+			return nil, "", "", err
+		}
+		if len(result.ToolCalls) == 0 {
+			return result.Raw, result.Text, result.ResponseId, nil
+		}
+
+		messages = append(messages, result.AssistantMessage)
+		for _, call := range result.ToolCalls {
+			emitToolEvent(emit, "tool_start", "tool", describeToolCall(call), call.CallID, call.Name, call.Arguments, "")
+			output, toolErr := c.executeTool(ctx, call.CallID, call.Name, call.Arguments)
+			if toolErr != nil {
+				output = fmt.Sprintf(`{"error":%q}`, toolErr.Error())
+				emitToolEvent(emit, "tool_result", "tool", fmt.Sprintf("tool %s failed", call.Name), call.CallID, call.Name, call.Arguments, toolErr.Error())
+			} else {
+				emitToolEvent(emit, "tool_result", "tool", fmt.Sprintf("tool %s completed", call.Name), call.CallID, call.Name, call.Arguments, output)
+			}
+			messages = append(messages, map[string]interface{}{
+				"role":         "tool",
+				"tool_call_id": call.CallID,
+				"content":      output,
+			})
+		}
+	}
+
+	return nil, "", "", apierrors.NewError(fmt.Errorf("tool loop exceeded max iterations"), http.StatusBadGateway)
+}
+
+func (c *controller) callChatCompletionsStream(
+	ctx context.Context,
+	endpoint, apiKey, modelName string,
+	maxTokens int,
+	messages, tools []map[string]interface{},
+	emit func(*types.AIStreamEvent) error,
+) (*chatStreamResult, error) {
+	payload := map[string]interface{}{
+		"model":      modelName,
+		"messages":   messages,
+		"stream":     true,
+		"max_tokens": maxTokens,
+	}
+	if len(tools) > 0 {
+		payload["tools"] = tools
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, apierrors.ErrServerInternal
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, apierrors.ErrServerInternal
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		klog.Errorf("failed to request ai endpoint %s: %v", endpoint, err)
+		return nil, apierrors.NewError(fmt.Errorf("request ai endpoint failed: %v", err), http.StatusBadGateway)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return nil, apierrors.NewError(fmt.Errorf("ai endpoint returned status %d: %s", resp.StatusCode, string(responseBody)), http.StatusBadGateway)
+	}
+
+	result, err := parseChatCompletionsSSE(resp.Body, emit)
+	if err != nil {
+		klog.Errorf("failed to parse chat completions stream: %v", err)
+		return nil, apierrors.NewError(fmt.Errorf("invalid ai response"), http.StatusBadGateway)
+	}
+	return result, nil
+}
+
+func parseChatCompletionsSSE(reader io.Reader, emit func(*types.AIStreamEvent) error) (*chatStreamResult, error) {
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var responseId string
+	var textBuilder strings.Builder
+	var usage map[string]interface{}
+	toolCalls := map[int]*chatToolCallAccumulator{}
+	seenEvent := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" || payload == "[DONE]" {
+			continue
+		}
+		var event map[string]interface{}
+		if err := json.Unmarshal([]byte(payload), &event); err != nil {
+			continue
+		}
+		seenEvent = true
+		if id, _ := event["id"].(string); id != "" {
+			responseId = id
+		}
+		if u, ok := event["usage"].(map[string]interface{}); ok {
+			usage = u
+		}
+		if errObject, ok := event["error"].(map[string]interface{}); ok {
+			message, _ := errObject["message"].(string)
+			return nil, errors.New(message)
+		}
+
+		choices, _ := event["choices"].([]interface{})
+		for _, choiceValue := range choices {
+			choice, _ := choiceValue.(map[string]interface{})
+			delta, _ := choice["delta"].(map[string]interface{})
+			if content, _ := delta["content"].(string); content != "" {
+				textBuilder.WriteString(content)
+				_ = emit(&types.AIStreamEvent{Type: "delta", Stage: "message", Delta: content})
+			}
+			deltas, _ := delta["tool_calls"].([]interface{})
+			for _, deltaValue := range deltas {
+				item, _ := deltaValue.(map[string]interface{})
+				index := int(toInt64(item["index"]))
+				accumulator := toolCalls[index]
+				if accumulator == nil {
+					accumulator = &chatToolCallAccumulator{Index: index}
+					toolCalls[index] = accumulator
+				}
+				if id, _ := item["id"].(string); id != "" {
+					accumulator.Id = id
+				}
+				function, _ := item["function"].(map[string]interface{})
+				if name, _ := function["name"].(string); name != "" {
+					accumulator.Name = name
+				}
+				if arguments, _ := function["arguments"].(string); arguments != "" {
+					accumulator.Arguments.WriteString(arguments)
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if !seenEvent {
+		return nil, fmt.Errorf("empty sse response")
+	}
+
+	indices := make([]int, 0, len(toolCalls))
+	for index := range toolCalls {
+		indices = append(indices, index)
+	}
+	sort.Ints(indices)
+	calls := make([]responseToolCall, 0, len(indices))
+	wireCalls := make([]map[string]interface{}, 0, len(indices))
+	for _, index := range indices {
+		call := toolCalls[index]
+		calls = append(calls, responseToolCall{CallID: call.Id, Name: call.Name, Arguments: call.Arguments.String()})
+		wireCalls = append(wireCalls, map[string]interface{}{
+			"id":   call.Id,
+			"type": "function",
+			"function": map[string]interface{}{
+				"name":      call.Name,
+				"arguments": call.Arguments.String(),
+			},
+		})
+	}
+	assistantMessage := map[string]interface{}{"role": "assistant", "content": textBuilder.String()}
+	if len(wireCalls) > 0 {
+		assistantMessage["tool_calls"] = wireCalls
+	}
+	raw := map[string]interface{}{
+		"id": responseId,
+		"choices": []interface{}{map[string]interface{}{
+			"message": assistantMessage,
+		}},
+	}
+	if usage != nil {
+		raw["usage"] = usage
+	}
+	return &chatStreamResult{
+		Raw: raw, Text: textBuilder.String(), ResponseId: responseId,
+		ToolCalls: calls, AssistantMessage: assistantMessage,
+	}, nil
+}
+
+func responseInputToChatMessages(inputItems []map[string]interface{}) []map[string]interface{} {
+	messages := make([]map[string]interface{}, 0, len(inputItems))
+	for _, item := range inputItems {
+		role, _ := item["role"].(string)
+		if role == "" {
+			continue
+		}
+		var parts []string
+		content, _ := item["content"].([]interface{})
+		for _, value := range content {
+			part, _ := value.(map[string]interface{})
+			if text, _ := part["text"].(string); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		if typedContent, ok := item["content"].([]map[string]interface{}); ok {
+			for _, part := range typedContent {
+				if text, _ := part["text"].(string); text != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+		messages = append(messages, map[string]interface{}{"role": role, "content": strings.Join(parts, "\n")})
+	}
+	return messages
+}
+
+func toChatCompletionsTools(tools []toolDefinition) []map[string]interface{} {
+	items := make([]map[string]interface{}, 0, len(tools))
+	for _, tool := range tools {
+		items = append(items, map[string]interface{}{
+			"type": "function",
+			"function": map[string]interface{}{
+				"name": tool.Name, "description": tool.Description, "parameters": tool.Parameters,
+			},
+		})
+	}
+	return items
+}

--- a/pkg/controller/assistant/provider_protocol.go
+++ b/pkg/controller/assistant/provider_protocol.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	apierrors "github.com/caoyingjunz/pixiu/api/server/errors"
+	"github.com/caoyingjunz/pixiu/pkg/db/model"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+const (
+	ProtocolOpenAIChat      = "openai_chat"
+	ProtocolOpenAIResponses = "openai_responses"
+)
+
+var versionPathPattern = regexp.MustCompile(`/v[0-9]+$`)
+
+func normalizeProtocol(protocol string) string {
+	return strings.ToLower(strings.TrimSpace(protocol))
+}
+
+func resolveAIEndpoint(provider *model.AIProvider) (string, error) {
+	if provider == nil || strings.TrimSpace(provider.BaseURL) == "" {
+		return "", apierrors.NewError(fmt.Errorf("ai provider base_url is empty"), http.StatusBadRequest)
+	}
+
+	var resource string
+	switch normalizeProtocol(provider.Protocol) {
+	case ProtocolOpenAIResponses:
+		resource = "responses"
+	case ProtocolOpenAIChat:
+		resource = "chat/completions"
+	default:
+		return "", apierrors.NewError(fmt.Errorf("unsupported ai protocol %q", provider.Protocol), http.StatusBadRequest)
+	}
+
+	baseURL := strings.TrimRight(strings.TrimSpace(provider.BaseURL), "/")
+	if versionPathPattern.MatchString(baseURL) {
+		return baseURL + "/" + resource, nil
+	}
+	return baseURL + "/v1/" + resource, nil
+}
+
+func (c *controller) runProviderStream(
+	ctx context.Context,
+	protocol, endpoint, apiKey, modelName string,
+	maxTokens int,
+	inputItems []map[string]interface{},
+	emit func(*types.AIStreamEvent) error,
+) (map[string]interface{}, string, string, error) {
+	switch normalizeProtocol(protocol) {
+	case ProtocolOpenAIResponses:
+		return c.runResponsesLoopStream(ctx, endpoint, apiKey, modelName, maxTokens, inputItems, emit)
+	case ProtocolOpenAIChat:
+		return c.runChatCompletionsLoopStream(ctx, endpoint, apiKey, modelName, maxTokens, inputItems, emit)
+	default:
+		return nil, "", "", apierrors.NewError(fmt.Errorf("unsupported ai protocol %q", protocol), http.StatusBadRequest)
+	}
+}

--- a/pkg/controller/assistant/provider_protocol_test.go
+++ b/pkg/controller/assistant/provider_protocol_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Pixiu Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package assistant
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/caoyingjunz/pixiu/pkg/db/model"
+	"github.com/caoyingjunz/pixiu/pkg/types"
+)
+
+func TestResolveAIEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider model.AIProvider
+		want     string
+	}{
+		{
+			name:     "openai responses root",
+			provider: model.AIProvider{BaseURL: "https://api.openai.com", Protocol: ProtocolOpenAIResponses},
+			want:     "https://api.openai.com/v1/responses",
+		},
+		{
+			name:     "siliconflow versioned root",
+			provider: model.AIProvider{BaseURL: "https://api.siliconflow.cn/v1/", Protocol: ProtocolOpenAIChat},
+			want:     "https://api.siliconflow.cn/v1/chat/completions",
+		},
+		{
+			name:     "zhipu versioned root",
+			provider: model.AIProvider{BaseURL: "https://open.bigmodel.cn/api/paas/v4", Protocol: ProtocolOpenAIChat},
+			want:     "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveAIEndpoint(&tt.provider)
+			if err != nil {
+				t.Fatalf("resolveAIEndpoint() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveAIEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseChatCompletionsSSE(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"id":"chat-1","choices":[{"delta":{"content":"hello "}}]}`,
+		`data: {"id":"chat-1","choices":[{"delta":{"content":"world"}}]}`,
+		`data: [DONE]`,
+	}, "\n\n")
+	var deltas []string
+	result, err := parseChatCompletionsSSE(strings.NewReader(stream), func(event *types.AIStreamEvent) error {
+		if event.Delta != "" {
+			deltas = append(deltas, event.Delta)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("parseChatCompletionsSSE() error = %v", err)
+	}
+	if result.ResponseId != "chat-1" || result.Text != "hello world" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if strings.Join(deltas, "") != "hello world" {
+		t.Fatalf("unexpected deltas: %#v", deltas)
+	}
+}

--- a/pkg/controller/assistant/respond.go
+++ b/pkg/controller/assistant/respond.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	apierrors "github.com/caoyingjunz/pixiu/api/server/errors"
-	"github.com/caoyingjunz/pixiu/pkg/db"
+	"github.com/caoyingjunz/pixiu/api/server/httputils"
 	"github.com/caoyingjunz/pixiu/pkg/db/model"
 	"github.com/caoyingjunz/pixiu/pkg/types"
 )
@@ -62,7 +62,7 @@ type responseUsage struct {
 
 func (c *controller) Stream(ctx context.Context, req *types.AIRespondRequest, emit func(*types.AIStreamEvent) error) (*types.AIRespondResponse, error) {
 	startTime := time.Now()
-	provider, err := c.getEnabledProvider(ctx, req.Provider)
+	account, provider, err := c.getAccountProvider(ctx, req.AccountId)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func (c *controller) Stream(ctx context.Context, req *types.AIRespondRequest, em
 		return nil, err
 	}
 
-	modelName := provider.ModelName
+	modelName := account.ModelName
 
 	inputItems, err := buildConversationInput(conversation, req.Input)
 	if err != nil {
@@ -92,7 +92,7 @@ func (c *controller) Stream(ctx context.Context, req *types.AIRespondRequest, em
 		RequestId:      getRequestIDFromContext(ctx),
 		ProviderId:     provider.Id,
 		ConversationId: req.ConversationId,
-		Provider:       provider.Provider,
+		Provider:       provider.Name,
 		ModelName:      modelName,
 		Authorization:  authorization,
 		Cookies:        cookies,
@@ -105,8 +105,11 @@ func (c *controller) Stream(ctx context.Context, req *types.AIRespondRequest, em
 		Model:   modelName,
 	})
 
-	endpoint := strings.TrimRight(provider.BaseURL, "/") + "/v1/responses"
-	raw, text, responseID, err := c.runResponsesLoopStream(ctx, endpoint, provider.APIKey, modelName, resolveProviderMaxTokens(provider), inputItems, emit)
+	endpoint, err := resolveAIEndpoint(provider)
+	if err != nil {
+		return nil, err
+	}
+	raw, text, responseID, err := c.runProviderStream(ctx, provider.Protocol, endpoint, account.APIKey, modelName, resolveProviderMaxTokens(provider), inputItems, emit)
 	if err != nil {
 		c.recordResponseExecution(ctx, provider, req.ConversationId, modelName, req.Input, "", "", nil, err, time.Since(startTime))
 		return nil, err
@@ -191,7 +194,7 @@ func (c *controller) recordResponseExecution(
 		RequestId:       meta.RequestId,
 		ProviderId:      provider.Id,
 		ConversationId:  conversationID,
-		Provider:        provider.Provider,
+		Provider:        provider.Name,
 		ModelName:       modelName,
 		ResponseId:      responseID,
 		InputText:       truncateAuditText(inputText),
@@ -368,25 +371,31 @@ func resolveProviderMaxTokens(provider *model.AIProvider) int {
 	return provider.MaxTokens
 }
 
-func (c *controller) getEnabledProvider(ctx context.Context, providerName string) (*model.AIProvider, error) {
-	opts := []db.Options{
-		db.WithEnabled(true),
-		db.WithModifyOrderByDesc(),
-		db.WithLimit(1),
-	}
-	if providerName != "" {
-		opts = append(opts, db.WithProvider(providerName))
-	}
-
-	providers, err := c.factory.Assistant().Provider().List(ctx, opts...)
+func (c *controller) getAccountProvider(ctx context.Context, accountId int64) (*model.AIAccount, *model.AIProvider, error) {
+	account, err := c.factory.Assistant().Account().Get(ctx, accountId)
 	if err != nil {
-		klog.Errorf("failed to list ai providers: %v", err)
-		return nil, apierrors.ErrServerInternal
+		klog.Errorf("failed to get ai account(%d): %v", accountId, err)
+		return nil, nil, apierrors.ErrServerInternal
 	}
-	if len(providers) == 0 {
-		return nil, apierrors.NewError(fmt.Errorf("no enabled ai provider found"), http.StatusNotFound)
+	if account == nil {
+		return nil, nil, apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
 	}
-	return &providers[0], nil
+	userId, err := httputils.GetUserIdFromContext(ctx)
+	if err != nil {
+		return nil, nil, apierrors.NewError(fmt.Errorf("failed to get current user"), http.StatusUnauthorized)
+	}
+	if account.UserId != userId {
+		return nil, nil, apierrors.NewError(fmt.Errorf("ai account not found"), http.StatusNotFound)
+	}
+	provider, err := c.factory.Assistant().Provider().Get(ctx, account.ProviderId)
+	if err != nil {
+		klog.Errorf("failed to get ai provider(%d): %v", account.ProviderId, err)
+		return nil, nil, apierrors.ErrServerInternal
+	}
+	if provider == nil {
+		return nil, nil, apierrors.NewError(fmt.Errorf("ai provider not found"), http.StatusNotFound)
+	}
+	return account, provider, nil
 }
 
 func buildConversationInput(conversation *model.Conversation, input string) ([]map[string]interface{}, error) {
@@ -445,7 +454,7 @@ func (c *controller) persistConversation(
 		}
 		object, err := c.factory.Assistant().Conversation().Create(ctx, &model.Conversation{
 			ProviderId:         provider.Id,
-			Provider:           provider.Provider,
+			Provider:           provider.Name,
 			ModelName:          modelName,
 			Title:              title,
 			PreviousResponseId: responseID,
@@ -460,7 +469,7 @@ func (c *controller) persistConversation(
 
 	updates := map[string]interface{}{
 		"provider_id":          provider.Id,
-		"provider":             provider.Provider,
+		"provider":             provider.Name,
 		"model":                modelName,
 		"previous_response_id": responseID,
 		"history":              history,
@@ -543,6 +552,12 @@ func extractResponseUsage(raw map[string]interface{}) responseUsage {
 		InputTokens:  toInt64(usageObj["input_tokens"]),
 		OutputTokens: toInt64(usageObj["output_tokens"]),
 		TotalTokens:  toInt64(usageObj["total_tokens"]),
+	}
+	if usage.InputTokens == 0 {
+		usage.InputTokens = toInt64(usageObj["prompt_tokens"])
+	}
+	if usage.OutputTokens == 0 {
+		usage.OutputTokens = toInt64(usageObj["completion_tokens"])
 	}
 
 	if details, ok := usageObj["input_tokens_details"].(map[string]interface{}); ok {

--- a/pkg/controller/provider/provider.go
+++ b/pkg/controller/provider/provider.go
@@ -50,23 +50,16 @@ func New(cfg config.Config, f db.ShareDaoFactory) Interface {
 }
 
 func (c *controller) Create(ctx context.Context, req *types.CreateProviderRequest) error {
-	if err := validateProviderFields(req.Provider, req.APIKey, req.BaseURL, req.Model); err != nil {
+	if err := validateProviderFields(req.Name, req.BaseURL, req.Protocol); err != nil {
 		return err
 	}
 
-	enabled := true
-	if req.Enabled != nil {
-		enabled = *req.Enabled
-	}
-
 	_, err := c.factory.Assistant().Provider().Create(ctx, &model.AIProvider{
-		APIKey:      req.APIKey,
-		BaseURL:     req.BaseURL,
-		Enabled:     enabled,
+		Name:        strings.TrimSpace(req.Name),
+		BaseURL:     strings.TrimRight(strings.TrimSpace(req.BaseURL), "/"),
+		Protocol:    normalizeProtocol(req.Protocol),
 		Description: req.Description,
 		MaxTokens:   resolveMaxTokens(req.MaxTokens, 0),
-		ModelName:   req.Model,
-		Provider:    req.Provider,
 	})
 	if err != nil {
 		klog.Errorf("failed to create assistant provider: %v", err)
@@ -77,7 +70,7 @@ func (c *controller) Create(ctx context.Context, req *types.CreateProviderReques
 }
 
 func (c *controller) Update(ctx context.Context, req *types.UpdateProviderRequest) error {
-	if err := validateProviderFields(req.Provider, req.APIKey, req.BaseURL, req.Model); err != nil {
+	if err := validateProviderFields(req.Name, req.BaseURL, req.Protocol); err != nil {
 		return err
 	}
 
@@ -89,19 +82,15 @@ func (c *controller) Update(ctx context.Context, req *types.UpdateProviderReques
 	if old == nil {
 		return apierrors.NewError(fmt.Errorf("assistant provider not found"), http.StatusNotFound)
 	}
-
-	enabled := old.Enabled
-	if req.Enabled != nil {
-		enabled = *req.Enabled
+	if old.Builtin {
+		return apierrors.NewError(fmt.Errorf("builtin assistant provider cannot be updated"), http.StatusForbidden)
 	}
 
 	updates := map[string]interface{}{
-		"provider":    req.Provider,
-		"api_key":     req.APIKey,
-		"base_url":    req.BaseURL,
-		"model":       req.Model,
+		"name":        strings.TrimSpace(req.Name),
+		"base_url":    strings.TrimRight(strings.TrimSpace(req.BaseURL), "/"),
+		"protocol":    normalizeProtocol(req.Protocol),
 		"description": req.Description,
-		"enabled":     enabled,
 	}
 	if req.MaxTokens > 0 {
 		updates["max_tokens"] = req.MaxTokens
@@ -126,6 +115,17 @@ func (c *controller) Delete(ctx context.Context, id int64) error {
 	}
 	if old == nil {
 		return apierrors.NewError(fmt.Errorf("assistant provider not found"), http.StatusNotFound)
+	}
+	if old.Builtin {
+		return apierrors.NewError(fmt.Errorf("builtin assistant provider cannot be deleted"), http.StatusForbidden)
+	}
+	accountCount, err := c.factory.Assistant().Account().Count(ctx, db.WithAIProviderId(id))
+	if err != nil {
+		klog.Errorf("failed to count ai accounts for provider(%d): %v", id, err)
+		return apierrors.ErrServerInternal
+	}
+	if accountCount > 0 {
+		return apierrors.NewError(fmt.Errorf("assistant provider still has accounts"), http.StatusConflict)
 	}
 
 	if err = c.factory.Assistant().Provider().Delete(ctx, id); err != nil {
@@ -160,12 +160,7 @@ func (c *controller) List(ctx context.Context, listOption types.ListOptions) (in
 		},
 	}
 
-	opts := []db.Options{
-		db.WithProvider(listOption.Provider),
-	}
-	if listOption.Enabled != nil {
-		opts = append(opts, db.WithEnabled(*listOption.Enabled))
-	}
+	opts := []db.Options{db.WithNameLike(listOption.NameSelector)}
 
 	var err error
 	pageResult.Total, err = c.factory.Assistant().Provider().Count(ctx, opts...)
@@ -206,13 +201,12 @@ func modelToType(object *model.AIProvider) *types.AIProvider {
 			GmtCreate:   object.GmtCreate,
 			GmtModified: object.GmtModified,
 		},
-		Provider:    object.Provider,
-		APIKey:      object.APIKey,
+		Name:        object.Name,
 		BaseURL:     object.BaseURL,
-		Model:       object.ModelName,
+		Protocol:    object.Protocol,
 		Description: object.Description,
-		Enabled:     object.Enabled,
 		MaxTokens:   resolveMaxTokens(object.MaxTokens, 0),
+		Builtin:     object.Builtin,
 	}
 }
 
@@ -226,18 +220,24 @@ func resolveMaxTokens(value, fallback int) int {
 	return 4096
 }
 
-func validateProviderFields(provider, apiKey, baseURL, model string) error {
-	if strings.TrimSpace(provider) == "" {
-		return apierrors.NewError(fmt.Errorf("provider is required"), http.StatusBadRequest)
-	}
-	if strings.TrimSpace(apiKey) == "" {
-		return apierrors.NewError(fmt.Errorf("api_key is required"), http.StatusBadRequest)
+func validateProviderFields(name, baseURL, protocol string) error {
+	if strings.TrimSpace(name) == "" {
+		return apierrors.NewError(fmt.Errorf("name is required"), http.StatusBadRequest)
 	}
 	if strings.TrimSpace(baseURL) == "" {
 		return apierrors.NewError(fmt.Errorf("base_url is required"), http.StatusBadRequest)
 	}
-	if strings.TrimSpace(model) == "" {
-		return apierrors.NewError(fmt.Errorf("model is required"), http.StatusBadRequest)
+	if strings.TrimSpace(protocol) == "" {
+		return apierrors.NewError(fmt.Errorf("protocol is required"), http.StatusBadRequest)
+	}
+	switch normalizeProtocol(protocol) {
+	case "openai_chat", "openai_responses":
+	default:
+		return apierrors.NewError(fmt.Errorf("unsupported protocol %q", protocol), http.StatusBadRequest)
 	}
 	return nil
+}
+
+func normalizeProtocol(protocol string) string {
+	return strings.ToLower(strings.TrimSpace(protocol))
 }

--- a/pkg/db/ai_account.go
+++ b/pkg/db/ai_account.go
@@ -21,31 +21,34 @@ import (
 	"time"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 
 	"github.com/caoyingjunz/pixiu/pkg/db/model"
 	"github.com/caoyingjunz/pixiu/pkg/util/errors"
 )
 
-type AIProviderInterface interface {
-	Create(ctx context.Context, object *model.AIProvider) (*model.AIProvider, error)
-	EnsureBuiltin(ctx context.Context, object *model.AIProvider) error
+type AIAccountInterface interface {
+	Create(ctx context.Context, object *model.AIAccount) (*model.AIAccount, error)
 	Update(ctx context.Context, id int64, resourceVersion int64, updates map[string]interface{}) error
 	Delete(ctx context.Context, id int64) error
-	Get(ctx context.Context, id int64) (*model.AIProvider, error)
-	List(ctx context.Context, opts ...Options) ([]model.AIProvider, error)
+	Get(ctx context.Context, id int64) (*model.AIAccount, error)
+	List(ctx context.Context, opts ...Options) ([]model.AIAccount, error)
 	Count(ctx context.Context, opts ...Options) (int64, error)
 }
 
-type aiProvider struct {
-	db *gorm.DB
+type aiAccount struct{ db *gorm.DB }
+
+func WithAIProviderId(providerId int64) Options {
+	return func(tx *gorm.DB) *gorm.DB {
+		if providerId == 0 {
+			return tx
+		}
+		return tx.Where("provider_id = ?", providerId)
+	}
 }
 
-func newAIProvider(db *gorm.DB) AIProviderInterface {
-	return &aiProvider{db}
-}
+func newAIAccount(db *gorm.DB) AIAccountInterface { return &aiAccount{db: db} }
 
-func (a *aiProvider) Create(ctx context.Context, object *model.AIProvider) (*model.AIProvider, error) {
+func (a *aiAccount) Create(ctx context.Context, object *model.AIAccount) (*model.AIAccount, error) {
 	now := time.Now()
 	object.GmtCreate = now
 	object.GmtModified = now
@@ -55,21 +58,11 @@ func (a *aiProvider) Create(ctx context.Context, object *model.AIProvider) (*mod
 	return object, nil
 }
 
-func (a *aiProvider) EnsureBuiltin(ctx context.Context, object *model.AIProvider) error {
-	now := time.Now()
-	object.GmtCreate = now
-	object.GmtModified = now
-	return a.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "name"}},
-		DoUpdates: clause.Assignments(map[string]interface{}{"builtin": true}),
-	}).Create(object).Error
-}
-
-func (a *aiProvider) Update(ctx context.Context, id int64, resourceVersion int64, updates map[string]interface{}) error {
+func (a *aiAccount) Update(ctx context.Context, id int64, resourceVersion int64, updates map[string]interface{}) error {
 	updates["gmt_modified"] = time.Now()
 	updates["resource_version"] = resourceVersion + 1
-
-	f := a.db.WithContext(ctx).Model(&model.AIProvider{}).Where("id = ? and resource_version = ?", id, resourceVersion).Updates(updates)
+	f := a.db.WithContext(ctx).Model(&model.AIAccount{}).
+		Where("id = ? and resource_version = ?", id, resourceVersion).Updates(updates)
 	if f.Error != nil {
 		return f.Error
 	}
@@ -79,8 +72,8 @@ func (a *aiProvider) Update(ctx context.Context, id int64, resourceVersion int64
 	return nil
 }
 
-func (a *aiProvider) Delete(ctx context.Context, id int64) error {
-	f := a.db.WithContext(ctx).Where("id = ?", id).Delete(&model.AIProvider{})
+func (a *aiAccount) Delete(ctx context.Context, id int64) error {
+	f := a.db.WithContext(ctx).Where("id = ?", id).Delete(&model.AIAccount{})
 	if f.Error != nil {
 		return f.Error
 	}
@@ -90,9 +83,9 @@ func (a *aiProvider) Delete(ctx context.Context, id int64) error {
 	return nil
 }
 
-func (a *aiProvider) Get(ctx context.Context, id int64) (*model.AIProvider, error) {
-	var object model.AIProvider
-	if err := a.db.WithContext(ctx).Where("id = ?", id).First(&object).Error; err != nil {
+func (a *aiAccount) Get(ctx context.Context, id int64) (*model.AIAccount, error) {
+	var object model.AIAccount
+	if err := a.db.WithContext(ctx).Preload("Provider").Where("id = ?", id).First(&object).Error; err != nil {
 		if errors.IsRecordNotFound(err) {
 			return nil, nil
 		}
@@ -101,8 +94,8 @@ func (a *aiProvider) Get(ctx context.Context, id int64) (*model.AIProvider, erro
 	return &object, nil
 }
 
-func (a *aiProvider) List(ctx context.Context, opts ...Options) ([]model.AIProvider, error) {
-	var objects []model.AIProvider
+func (a *aiAccount) List(ctx context.Context, opts ...Options) ([]model.AIAccount, error) {
+	var objects []model.AIAccount
 	tx := a.db.WithContext(ctx)
 	for _, opt := range opts {
 		tx = opt(tx)
@@ -113,9 +106,9 @@ func (a *aiProvider) List(ctx context.Context, opts ...Options) ([]model.AIProvi
 	return objects, nil
 }
 
-func (a *aiProvider) Count(ctx context.Context, opts ...Options) (int64, error) {
+func (a *aiAccount) Count(ctx context.Context, opts ...Options) (int64, error) {
 	var total int64
-	tx := a.db.WithContext(ctx).Model(&model.AIProvider{})
+	tx := a.db.WithContext(ctx).Model(&model.AIAccount{})
 	for _, opt := range opts {
 		tx = opt(tx)
 	}

--- a/pkg/db/assistant.go
+++ b/pkg/db/assistant.go
@@ -21,6 +21,7 @@ import "gorm.io/gorm"
 // AssistantInterface groups all assistant-related database accessors.
 type AssistantInterface interface {
 	Provider() AIProviderInterface
+	Account() AIAccountInterface
 	Conversation() ConversationInterface
 	Execution() ExecutionInterface
 	Message() MessageInterface
@@ -36,6 +37,10 @@ func newAssistant(db *gorm.DB) AssistantInterface {
 
 func (a *assistant) Provider() AIProviderInterface {
 	return newAIProvider(a.db)
+}
+
+func (a *assistant) Account() AIAccountInterface {
+	return newAIAccount(a.db)
 }
 
 func (a *assistant) Conversation() ConversationInterface {

--- a/pkg/db/model/assistant.go
+++ b/pkg/db/model/assistant.go
@@ -19,26 +19,39 @@ package model
 import "github.com/caoyingjunz/pixiu/pkg/db/model/pixiu"
 
 func init() {
-	register(&AIProvider{}, &Conversation{}, &Message{}, &Execution{})
+	register(&AIProvider{}, &AIAccount{}, &Conversation{}, &Message{}, &Execution{})
 }
 
-// AIProvider stores API credentials for a local user.
+// AIProvider stores an AI vendor endpoint and its wire protocol.
 type AIProvider struct {
 	pixiu.Model
 
-	Name        string `gorm:"column:name;type:varchar(128)" json:"name"` // 如: deepseek, openAI
-	APIKey      string `gorm:"column:api_key;type:text;not null" json:"api_key"`
-	BaseURL     string `gorm:"column:base_url;type:varchar(512)" json:"base_url"`
-	Enabled     bool   `gorm:"not null;default:true" json:"enabled"`
-	Description string `gorm:"type:text" json:"description"`
-	MaxTokens   int    `gorm:"default:4096" json:"max_tokens"`
-
-	ModelName string `gorm:"column:model;type:varchar(128)" json:"model"`
-	Provider  string `gorm:"type:varchar(64);not null" json:"provider"`
+	Name        string `gorm:"column:name;type:varchar(128);not null;uniqueIndex:uk_ai_providers_name" json:"name"`
+	BaseURL     string `gorm:"column:base_url;type:varchar(512);not null" json:"base_url"`
+	Protocol    string `gorm:"column:protocol;type:varchar(32);not null" json:"protocol"`
+	Description string `gorm:"column:description;type:text" json:"description"`
+	MaxTokens   int    `gorm:"column:max_tokens;not null;default:4096" json:"max_tokens"`
+	Builtin     bool   `gorm:"column:builtin;not null;default:false" json:"builtin"`
 }
 
 func (AIProvider) TableName() string {
 	return "ai_providers"
+}
+
+// AIAccount stores one model credential belonging to an AI provider.
+type AIAccount struct {
+	pixiu.Model
+
+	UserId     int64       `gorm:"column:user_id;not null;index:idx_ai_accounts_user_id;uniqueIndex:uk_ai_accounts_user_provider_name,priority:1" json:"user_id"`
+	ProviderId int64       `gorm:"column:provider_id;not null;index:idx_ai_accounts_provider_id;uniqueIndex:uk_ai_accounts_user_provider_name,priority:2" json:"provider_id"`
+	Name       string      `gorm:"column:name;type:varchar(128);not null;uniqueIndex:uk_ai_accounts_user_provider_name,priority:3" json:"name"`
+	APIKey     string      `gorm:"column:api_key;type:text;not null" json:"-"`
+	ModelName  string      `gorm:"column:model;type:varchar(128);not null" json:"model"`
+	Provider   *AIProvider `gorm:"foreignKey:ProviderId;references:Id" json:"-"`
+}
+
+func (AIAccount) TableName() string {
+	return "ai_accounts"
 }
 
 // Conversation stores persisted response-chain context for one user conversation.

--- a/pkg/types/request.go
+++ b/pkg/types/request.go
@@ -99,25 +99,37 @@ type (
 	}
 
 	CreateProviderRequest struct {
-		Provider    string `json:"provider" binding:"required"`
-		APIKey      string `json:"api_key" binding:"required"`
+		Name        string `json:"name" binding:"required"`
 		BaseURL     string `json:"base_url" binding:"required,url"`
-		Model       string `json:"model" binding:"required"`
+		Protocol    string `json:"protocol" binding:"required"`
 		Description string `json:"description" binding:"omitempty"`
-		Enabled     *bool  `json:"enabled" binding:"omitempty"`
 		MaxTokens   int    `json:"max_tokens" binding:"omitempty"`
 	}
 
 	UpdateProviderRequest struct {
 		PixiuMeta `json:",inline"`
 
-		Provider    string `json:"provider" binding:"required"`
-		APIKey      string `json:"api_key" binding:"required"`
+		Name        string `json:"name" binding:"required"`
 		BaseURL     string `json:"base_url" binding:"required,url"`
-		Model       string `json:"model" binding:"required"`
+		Protocol    string `json:"protocol" binding:"required"`
 		Description string `json:"description" binding:"omitempty"`
-		Enabled     *bool  `json:"enabled" binding:"omitempty"`
 		MaxTokens   int    `json:"max_tokens" binding:"omitempty"`
+	}
+
+	CreateAIAccountRequest struct {
+		Name       string `json:"name" binding:"required"`
+		APIKey     string `json:"api_key" binding:"required"`
+		Model      string `json:"model" binding:"required"`
+		ProviderId int64  `json:"provider_id" binding:"required"`
+	}
+
+	UpdateAIAccountRequest struct {
+		PixiuMeta `json:",inline"`
+
+		Name       string `json:"name" binding:"required"`
+		APIKey     string `json:"api_key" binding:"omitempty"`
+		Model      string `json:"model" binding:"required"`
+		ProviderId int64  `json:"provider_id" binding:"required"`
 	}
 
 	CreateTenantRequest struct {
@@ -244,7 +256,7 @@ type (
 
 	AIRespondRequest struct {
 		ConversationId int64  `json:"conversation_id"`
-		Provider       string `json:"provider"`
+		AccountId      int64  `json:"account_id" binding:"required"`
 		Input          string `json:"input" binding:"required"`
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -133,13 +133,24 @@ type AIProvider struct {
 	PixiuMeta `json:",inline"`
 	TimeMeta  `json:",inline"`
 
-	Provider    string `json:"provider"`
-	APIKey      string `json:"api_key"`
+	Name        string `json:"name"`
 	BaseURL     string `json:"base_url"`
-	Model       string `json:"model"`
+	Protocol    string `json:"protocol"`
 	Description string `json:"description"`
-	Enabled     bool   `json:"enabled"`
 	MaxTokens   int    `json:"max_tokens"`
+	Builtin     bool   `json:"builtin"`
+}
+
+type AIAccount struct {
+	PixiuMeta `json:",inline"`
+	TimeMeta  `json:",inline"`
+
+	Name       string      `json:"name"`
+	APIKey     string      `json:"api_key"`
+	Model      string      `json:"model"`
+	ProviderId int64       `json:"provider_id"`
+	UserId     int64       `json:"user_id"`
+	Provider   *AIProvider `json:"provider,omitempty"`
 }
 
 type Conversation struct {
@@ -437,6 +448,7 @@ type CustomMeta struct {
 	ClusterName    string                `form:"cluster_name" json:"cluster_name"`
 	DatasourceType *model.DatasourceType `form:"datasource_type" json:"datasource_type"`
 	Provider       string                `form:"provider" json:"provider"`
+	ProviderId     int64                 `form:"provider_id" json:"provider_id"`
 	Enabled        *bool                 `form:"enabled" json:"enabled"`
 	ConversationId int64                 `form:"conversation_id" json:"conversation_id"`
 


### PR DESCRIPTION
## Summary
- split AI providers from user-owned AI accounts
- bootstrap protected built-in providers for OpenAI, DeepSeek, SiliconFlow, and Zhipu
- support account selection and provider-aware AI requests
- preload provider details only for account GET

## Testing
- go test ./...